### PR TITLE
Hotfix/broken results action

### DIFF
--- a/src/controllers/HealthCheckController.php
+++ b/src/controllers/HealthCheckController.php
@@ -8,7 +8,7 @@ use yii\web\ForbiddenHttpException;
 
 class HealthCheckController extends Controller
 {
-    protected $allowAnonymous = ['results'];
+    protected array|bool|int $allowAnonymous = ['results'];
 
     public function actionResults()
     {


### PR DESCRIPTION
Hi there! Using v4 with Craft 4 throws the following error when accessing the results page:

```
Type of webhubworks\ohdear\controllers\HealthCheckController::$allowAnonymous must be array|int|bool (as in class craft\web\Controller)
```

This change appears to fix it. Thanks for all your efforts on this plugin!