### PR TITLE
Prioritise Critical updates over total update count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## 4.3.1 - 2023-11-08
+
+### Changed
+- Prioritise critical available updates over total update count when determining the failed or warning state in the Available Updates Health Check
+
 ## 4.3.0 - 2023-10-07
 
 ### Added

--- a/src/health/checks/AvailableUpdatesCheck.php
+++ b/src/health/checks/AvailableUpdatesCheck.php
@@ -32,14 +32,14 @@ class AvailableUpdatesCheck extends Check
             ],
         ));
 
-        if ($totalUpdates >= $this->warningThreshold) {
-            return $result->status(CheckResult::STATUS_WARNING)
-                ->notificationMessage($totalUpdates === 1 ? "There is a Craft or plugin update available!" : "There are {$totalUpdates} Craft or plugin updates available!");
-        }
-
         if ($hasCritical) {
             return $result->status(CheckResult::STATUS_FAILED)
                 ->notificationMessage('There are one or more critical Craft or plugin updates available!');
+        }
+        
+        if ($totalUpdates >= $this->warningThreshold) {
+            return $result->status(CheckResult::STATUS_WARNING)
+                ->notificationMessage($totalUpdates === 1 ? "There is a Craft or plugin update available!" : "There are {$totalUpdates} Craft or plugin updates available!");
         }
 
         return $result->status(CheckResult::STATUS_OK)


### PR DESCRIPTION
## 4.3.1 - 2023-11-08

### Changed
- Prioritise critical available updates over total update count when determing the failed or warning state in the Available Updates Health Check