### PR TITLE
Fix? duplicate check name

### DIFF
--- a/src/health/checks/FailedJobsCheck.php
+++ b/src/health/checks/FailedJobsCheck.php
@@ -33,7 +33,7 @@ class FailedJobsCheck extends Check
         $failedJobCount = \Craft::$app->getQueue()->getTotalFailed();
 
         $result = (new CheckResult(
-            name: 'Queue',
+            name: 'FailedJobs',
             label: 'Failed jobs',
             shortSummary: $failedJobCount,
             meta: [


### PR DESCRIPTION
Hi,
I'm not entirely sure about this, but it seems like if two checks have the same `name` attribute (eg. bith the 'Failed Jobs' and the 'Queue' checks have `name: 'Queue'`), OhDear will only pick up one of them. At least in my cas only the first one is shown in the dashboard. Thanks a lot! 