### PR TITLE
Plugin Initialisation

### DIFF
--- a/src/OhDear.php
+++ b/src/OhDear.php
@@ -98,18 +98,21 @@ class OhDear extends Plugin
 
         $this->registerPermissions();
 
-        if (Craft::$app->request->isCpRequest && Craft::$app->user->getIdentity()) {
-            OhDearAsset::registerLangFile();
-            $this->registerFrontendPermissions();
-            $this->registerWidgets();
-            $this->registerUtilityTypes();
-        }
-
-        $this->registerUrlRules();
-
-        $this->registerCpRoutes();
-
-        $this->registerEntryEditRedirectOverride();
+        Craft::$app->onInit(function () {
+            
+            if (Craft::$app->request->isCpRequest && Craft::$app->user->getIdentity()) {
+                OhDearAsset::registerLangFile();
+                $this->registerFrontendPermissions();
+                $this->registerWidgets();
+                $this->registerUtilityTypes();
+            }
+    
+            $this->registerUrlRules();
+    
+            $this->registerCpRoutes();
+    
+            $this->registerEntryEditRedirectOverride();
+        });
     }
 
     protected function createSettingsModel(): ?Model


### PR DESCRIPTION
Hi there,

Calling `Craft::$app->getUser()->getIdentity()` in the init method leads to the logs being flooded with the following warning: `[craft\elements\db\ElementQuery::prepare] Element query executed before Craft is fully initialized.`

I guess registering everything once Craft is ready would fix this.

Thanks!
